### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/offsom/sliver/security/code-scanning/2](https://github.com/offsom/sliver/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to the workflow file `.github/workflows/autorelease.yml`. The block should be placed at the top level (before `jobs:`) so that it applies to all jobs in the workflow unless overridden. The minimal required permission for these jobs is `contents: read`, which allows the workflow to read repository contents but not modify them. This change does not affect existing functionality, as none of the jobs require write access to repository contents. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
